### PR TITLE
Web Console: update extension points

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -108,7 +108,9 @@
     <script src="bower_components/yamljs/bin/yaml.js"></script>
     <script src="bower_components/clipboard/dist/clipboard.js"></script>
     <script src="bower_components/pathseg/pathseg.js"></script>
-    <script src="bower_components/ansi_up/ansi_up.js"></script>
+	  <script src="bower_components/ansi_up/ansi_up.js"></script>
+    <script src="bower_components/angular-extension-registry/dist/angular-extension-registry.min.js"></script>
+    <script src="bower_components/angular-extension-registry/dist/compiled-templates.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -23,7 +23,8 @@ angular
     'patternfly.charts',
     'patternfly.sort',
     'openshiftConsoleTemplates',
-    'ui.ace'
+    'ui.ace',
+    'extension-registry'
   ])
   .constant("mainNavTabs", [])  // even though its not really a "constant", it has to be created as a constant and not a value
                          // or it can't be referenced during module config
@@ -338,6 +339,30 @@ angular
         return durationFilter(timestamp, null, omitSingle, precision) || existing;
       });
     }, 1000);
+  })
+  // prepopulating extension points with some of our own data
+  // (ensures a single interface for extending the UI)
+  .run(function(extensionRegistry) {
+    extensionRegistry
+      .add('nav-help-dropdown', function() {
+        return [
+          {
+            type: 'dom',
+            node: '<li><a href="https://docs.openshift.org/latest/welcome/index.html">Documentation</a></li>'
+          },
+          {
+            type: 'dom',
+            node: '<li><a href="about">About</a></li>'
+          }
+        ];
+      });
+    extensionRegistry
+      .add('nav-user-dropdown', function() {
+        return [{
+          type: 'dom',
+          node: '<li><a href="logout">Log out</a></li>'
+        }];
+      });
   });
 
 hawtioPluginLoader.addModule('openshiftConsole');

--- a/assets/app/scripts/extensions/javaLink.js
+++ b/assets/app/scripts/extensions/javaLink.js
@@ -1,86 +1,79 @@
 'use strict';
 
-/**
- * @ngdoc function
- * @name openshiftConsoleExtensions.extension:JavaLinkController
- * @description
- * # ProjectController
- * Controller of the openshiftConsole
- */
-angular.module('openshiftConsoleExtensions', ['openshiftConsole'])
-  .factory("ProxyPod", function(DataService) {
-    return function(namespace, podName, port) {
-      return new URI(DataService.url({
-        resource: 'pods/proxy',
-        // always use https when connecting to jolokia in a pod
-        name: ['https', podName, port || ''].join(':'),
-        namespace: namespace
-      }));
-    };
-  })
-  .run(function(ProxyPod, BaseHref, HawtioExtension, $templateCache, $compile, AuthService) {
+angular
+  .module('openshiftConsoleExtensions')
+  .run([
+    'AuthService',
+    'BaseHref',
+    'DataService',
+    'extensionRegistry',
+    function(AuthService, BaseHref, DataService, extensionRegistry) {
 
-    var template = [
-      '<div row ',
+      var template = [
+        '<div row ',
+        'ng-show="item.url" ',
         'class="icon-row" ',
-        'ng-show="jolokiaUrl" ',
         'title="Connect to container">',
-        '<div>',
-          '<i class="fa fa-share" aria-hidden="true"></i>',
-        '</div>',
-        '<div flex>',
-          '<a ng-click="gotoContainerView($event, container, jolokiaUrl)" ng-href="jolokiaUrl">',
-            'Open Java Console',
-          '</a>',
-        '</div>',
-      '</div>'
-    ].join('');
+          '<div>',
+            '<i class="fa fa-share" aria-hidden="true"></i>',
+          '</div>',
+          '<div flex>',
+            '<a ng-click="item.onClick($event)" ',
+              'ng-href="item.url">',
+              'Open Java Console',
+            '</a>',
+          '</div>',
+        '</div>'
+      ].join('');
 
-    HawtioExtension.add('container-links', function ($scope) {
-      var container = $scope.container;
-      if (!container) {
-        return;
-      }
-      var jolokiaPort = _.find((container.ports || []), function(port) {
-        return port.name && port.name.toLowerCase() === 'jolokia';
-      });
-      if (!jolokiaPort) {
-        return;
-      }
-      var pod = $scope.$eval('podTemplate');
-      // TODO distinguish between pod and pod templates for now...
-      if (!pod || !pod.status || pod.status.phase !== 'Running') {
-        return;
-      }
-      var containerStatuses = pod.status.containerStatuses;
-      var containerStatus = _.find(containerStatuses, function(status) {
-        return status.name === container.name;
-      });
-      if (!containerStatus || !containerStatus.ready) {
-        return;
-      }
-      var podName = pod.metadata.name;
-      var namespace = pod.metadata.namespace;
-      $scope.jolokiaUrl = ProxyPod(namespace, podName, jolokiaPort.containerPort).segment('jolokia/').toString();
-      $scope.gotoContainerView = function($event, container, jolokiaUrl) {
-        $event.preventDefault();
-        $event.stopPropagation();
-        var returnTo = window.location.href;
-        var title = container.name || 'Untitled Container';
-        var token = AuthService.UserStore().getToken() || '';
-        var targetURI = new URI().path(BaseHref)
-                                 .segment('java/') // Must have a trailing slash to avoid runtime errors in Safari
-                                 .hash(token)
-                                 .query({
-                                   jolokiaUrl: jolokiaUrl,
-                                   title: title,
-                                   returnTo: returnTo
-                                 });
-        window.location.href = targetURI.toString();
+      var makeJolokiaUrl = function(namespace, podName, port) {
+        return new URI(DataService.url({
+                    resource: 'pods/proxy',
+                    // always use https when connecting to jolokia in a pod
+                    name: ['https', podName, port || ''].join(':'),
+                    namespace: namespace
+                  }))
+                  .segment('jolokia/');
       };
-      var answer = $compile(template)($scope);
-      return answer;
-    });
-  });
 
-hawtioPluginLoader.addModule('openshiftConsoleExtensions');
+      extensionRegistry.add('container-links', _.spread(function(container, pod) {
+        var jolokiaPort = _.find((container.ports || []), function(port) {
+          return port.name && port.name.toLowerCase() === 'jolokia';
+        });
+        if (!jolokiaPort) {
+          return;
+        }
+        if(_.get(pod, 'status.phase') !== 'Running') {
+          return;
+        }
+        var podName = pod.metadata.name;
+        var namespace = pod.metadata.namespace;
+        var jolokiaUrl = makeJolokiaUrl(namespace, podName, jolokiaPort.containerPort).toString();
+        var gotoContainerView = function($event) {
+          $event.preventDefault();
+          $event.stopPropagation();
+          var returnTo = window.location.href;
+          var title = container.name || 'Untitled Container';
+          var token = AuthService.UserStore().getToken() || '';
+          var targetURI = new URI().path(BaseHref)
+                                   .segment('java/') // Must have a trailing slash to avoid runtime errors in Safari
+                                   .hash(token)
+                                   .query({
+                                     jolokiaUrl: jolokiaUrl,
+                                     title: title,
+                                     returnTo: returnTo
+                                   });
+
+          window.location.href = targetURI.toString();
+        };
+
+        return {
+          type: 'dom',
+          node: template,
+          onClick: gotoContainerView,
+          url: jolokiaUrl
+        };
+
+      }));
+    }
+  ]);

--- a/assets/app/styles/_navbar-alt.less
+++ b/assets/app/styles/_navbar-alt.less
@@ -114,7 +114,10 @@
     cursor: pointer;
     line-height: 1;
     max-height: (@navbar-pf-alt-height - @navbar-pf-alt-border-width); // to keep Firefox from oversizing icons
-    padding: 21px 14px;
+    padding-left: 14px;
+    padding-right: 14px;
+    padding-top: @navbar-padding-vertical;
+    padding-bottom: @navbar-padding-vertical;
     position: relative;
     color: @navbar-pf-alt-color;
     margin-right: 0;
@@ -122,11 +125,11 @@
     .username, .status-issue {
       display: inline-block;
       font-weight: 300;
+      line-height: 1;
       max-width: 100px;
       padding: 0 2px;
       position: relative;
       top: -2px;
-      vertical-align: bottom;
     }
     &:hover, &:focus {
       background-color: transparent;
@@ -146,7 +149,6 @@
       height: 12px;
     }
     .status-icon {
-      font-size: 18px;
       padding-right: 2px;
     }
   }
@@ -158,6 +160,13 @@
         color: @navbar-pf-alt-active-color;
       }
     }
+  }
+}
+
+@media (min-width: @screen-sm-min) {
+  .navbar-pf-alt .nav-item-iconic {
+    display: block;
+    padding: 21px 14px;
   }
 }
 

--- a/assets/app/views/_pod-template.html
+++ b/assets/app/views/_pod-template.html
@@ -127,7 +127,11 @@
         </div>
       </div>
 
-      <div hawtio-extension name="container-links"></div>
+      <div
+        extension-point
+        extension-name="container-links"
+        extension-types="link dom"
+        extension-args="[container, podTemplate]"></div>   
 
     </div>
   </div>

--- a/assets/app/views/directives/header/_navbar-utility.html
+++ b/assets/app/views/directives/header/_navbar-utility.html
@@ -1,25 +1,33 @@
 <ul class="nav navbar-nav navbar-right navbar-iconic">
-  <li hawtio-extension name="nav-system-status"></li>
+  <li
+    extension-point
+    extension-name="nav-system-status"
+    extension-types="dom"></li>
+
   <li uib-dropdown>
-    <a uib-dropdown-toggle class="nav-item-iconic" id="dropdownMenu1">
+    <a uib-dropdown-toggle class="nav-item-iconic" id="dropdownMenu1" href="">
       <span title="Help" class="fa pficon-help" aria-hidden="true"></span>
       <span class="sr-only">Help</span>
       <span class="caret" aria-hidden="true"></span>
     </a>
-    <ul class="uib-dropdown-menu" aria-labelledby="dropdownMenu1" hawtio-extension name="nav-help-dropdown">
-      <li><a href="https://docs.openshift.org/latest/welcome/index.html">Documentation</a></li>
-      <li><a href="about">About</a></li>
-    </ul>
+    <ul
+      class="uib-dropdown-menu" aria-labelledby="dropdownMenu1"
+      extension-point
+      extension-name="nav-help-dropdown"
+      extension-types="dom html"><!-- extension points generated here --></ul>
   </li>
+
   <li uib-dropdown ng-cloak ng-if="user">
     <a href="" uib-dropdown-toggle id="user-dropdown" class="nav-item-iconic">
       <span class="pf-icon pficon-user" aria-hidden="true"></span>
       <span class="username truncate">{{user.fullName || user.metadata.name}}</span> <span class="caret" aria-hidden="true"></span>
     </a>
-    <ul class="uib-dropdown-menu" aria-labelledby="user-dropdown" hawtio-extension name="nav-user-dropdown">
-      <li>
-        <a href="logout">Log out</a>
-      </li>
-    </ul>
+
+    <ul
+      class="uib-dropdown-menu"
+      aria-labelledby="user-dropdown"
+      extension-point
+      extension-name="nav-user-dropdown"
+      extension-types="dom html"><!-- extension points generated here --></ul>
   </li>
 </ul>

--- a/assets/app/views/directives/header/default-header.html
+++ b/assets/app/views/directives/header/default-header.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-pf-alt" role="navigation">
-  <div row hawtio-extension name="nav-system-status-mobile">
+  <div row>
     <div class="navbar-header">
       <!-- mobile nav menu -->
       <div row flex class="navbar-flex-btn toggle-menu">
@@ -17,6 +17,13 @@
     </div>
     <!-- system status message at mobile -->
 
-    <navbar-utility class="collapse navbar-collapse"></navbar-utility>  
+    <navbar-utility class="collapse navbar-collapse"></navbar-utility>
+
+    <div row
+      extension-point
+      extension-name="nav-system-status-mobile"
+      extension-types="dom"
+      class="navbar-flex-btn"></div>
+
   </div>
 </nav>

--- a/assets/app/views/directives/header/project-header.html
+++ b/assets/app/views/directives/header/project-header.html
@@ -3,7 +3,7 @@
     <a class="navbar-home" href="./"><span class="fa-fw pficon pficon-home" aria-hidden="true"></span> <span class="visible-xlg-inline-block"> Projects</span></a>
   </div>
   <div class="nav navbar-project-menu">
-    <div row hawtio-extension name="nav-system-status-mobile">
+    <div row>
       <!-- mobile nav menu -->
       <div row flex class="navbar-flex-btn toggle-menu">
         <button type="button" class="navbar-toggle project-action-btn ng-isolate-scope" data-toggle="collapse" data-target=".navbar-collapse-1">
@@ -24,6 +24,13 @@
           <i class="fa fa-plus visible-xs-inline-block"></i><span class="hidden-xs">Add to project</span>
         </a>
       </div>
+
+      <div row
+        extension-point
+        extension-name="nav-system-status-mobile"
+        extension-types="dom"
+        class="navbar-flex-btn"></div>
+
     </div>
   </div> <!-- /navbar-project-menu -->
   <navbar-utility class="hidden-xs"></navbar-utility>

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -37,7 +37,8 @@
     "clipboard": "1.5.8",
     "pathseg": "1.0.2",
     "ansi_up": "1.3.0",
-    "pathseg": "1.0.2"
+    "pathseg": "1.0.2",
+	  "angular-extension-registry": "1.2.6"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",

--- a/assets/extensions/examples/online-extensions.js
+++ b/assets/extensions/examples/online-extensions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
   This file contains extensions being used by the OpenShift Online Developer Preview
   They can be used as reference examples.
@@ -30,76 +32,71 @@ window.OPENSHIFT_CONSTANTS.HELP = {
   "default":                 "https://docs.openshift.com/online/latest/welcome/index.html"
 };
 
-/*
-  Custom angular module 
-*/
-angular.module('openshiftOnlineConsoleExtensions', ['openshiftConsole'])
-  .run(function(HawtioExtension) {
 
-    /*
-      Request system status from statuspage.io
-    */
-    var system_status_elem = $('<a href="http://status.openshift.com/" target="_blank" class="nav-item-iconic system-status project-action-btn" style="display: none;">');
-    var system_status_elem_mobile = $('<div row flex class="navbar-flex-btn system-status-mobile" style="display: none;">');
+angular
+  .module('openshiftConsoleExtensions')
+  .run([
+    'extensionRegistry',
+    function(extensionRegistry) {
 
-    $.getJSON("https://m0sg3q4t415n.statuspage.io/api/v2/summary.json", function (data) {
-      var n = (data.incidents || [ ]).length;
-    
-      if (n > 0) {
-        var issueStr = n + ' open issue';
-        if (n !== 1) {
-          issueStr += "s";
+      var system_status_elem = $('<a href="http://status.openshift.com/" target="_blank" class="nav-item-iconic system-status project-action-btn" style="display: none;">');
+      var system_status_elem_mobile = $('<div row flex class="navbar-flex-btn system-status-mobile" style="display: none;">');
+
+
+      $.getJSON("https://m0sg3q4t415n.statuspage.io/api/v2/summary.json", function (data) {
+        var n = (data.incidents || [ ]).length;
+        n = 32;
+        if (n > 0) {
+          var issueStr = n + ' open issue';
+          if (n !== 1) {
+            issueStr += "s";
+          }
+          $('<span title="System Status" class="fa status-icon pficon-warning-triangle-o"></span>').appendTo(system_status_elem);
+          $('<span class="status-issue">' + issueStr + '</span>').appendTo(system_status_elem);
+          system_status_elem.css('display', '');
+
+          system_status_elem_mobile.append(system_status_elem.clone());
+          system_status_elem_mobile.css('display', '');
         }
-        $('<span title="System Status" class="fa status-icon pficon-warning-triangle-o"></span>').appendTo(system_status_elem);
-        $('<span class="status-issue">' + issueStr + '</span>').appendTo(system_status_elem);
-        system_status_elem.css('display', '');
+      });
 
-        system_status_elem_mobile.append(system_status_elem.clone());
-        system_status_elem_mobile.css('display', '');
-      }
-    });
 
-    /*
-      Render system status into the extension point in the top navigation bar
-    */
-    HawtioExtension.add('nav-system-status', function ($scope) {
-      return system_status_elem;
-    });
+      extensionRegistry
+        .add('nav-system-status', function() {
+          return [{
+            type: 'dom',
+            node: system_status_elem
+          }];
+        });
 
-    HawtioExtension.add('nav-system-status-mobile', function ($scope) {
-      return system_status_elem_mobile;
-    });    
 
-    /*
-      Add additional items to the help dropdown in the top navigation bar
-    */
-    HawtioExtension.add('nav-help-dropdown', function ($scope) {
-      var li = $('<li>');
-        $('<a href="https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Online" target="_blank">Report a Bug</a>')
-          .appendTo(li);
-      return li;
-    });
+      extensionRegistry
+        .add('nav-system-status-mobile', function() {
+          return [{
+            type: 'dom',
+            node: system_status_elem_mobile
+          }];
+        });
 
-    HawtioExtension.add('nav-help-dropdown', function ($scope) {
-      var li = $('<li>');
-        $('<a href="https://stackoverflow.com/tags/openshift" target="_blank">Stack Overflow</a>')
-          .appendTo(li);
-      return li;
-    });    
 
-    HawtioExtension.add('nav-help-dropdown', function ($scope) {
-      return $('<li class="divider">');
-    });
+      extensionRegistry
+        .add('nav-help-dropdown', function() {
+          return [
+            {
+              type: 'dom',
+              node: '<li><a href="https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Online" target="_blank">Report a Bug</a></li>'
+            }, {
+              type: 'dom',
+              node: '<li><a href="https://stackoverflow.com/tags/openshift" target="_blank">Stack Overflow</a></li>'
+            }, {
+              type: 'dom',
+              node: '<li class="divider"></li>'
+            }, {
+              type: 'dom',
+              node: '<li><a href="http://status.openshift.com/" target="_blank">System Status</a></li>'
+            }
+          ];
+        });
 
-    HawtioExtension.add('nav-help-dropdown', function ($scope) {
-      var li = $('<li>');
-        $('<a href="http://status.openshift.com/" target="_blank">System Status</a>')
-          .appendTo(li);
-      return li;
-    });    
-  });
-
-/*
-  Register the custom angular module
-*/
-hawtioPluginLoader.addModule('openshiftOnlineConsoleExtensions');
+    }
+  ]);


### PR DESCRIPTION
Update extension points from hawtio manager to angular-extension-registry

    - Add angular-extension-registry
        - TODO: register openshift/angular-extension-registry w/bower & update
    - Update hawtio javalink extension to new manager
    - Update online-extensions
    - Swap java console link icon to fa-share
    - Update extensions nav-system-status, nav-system-status-mobile, nav-user-dropdown
    - eliminate documtentation & about link html, register as extension in run block
    - Move logout link into extension
    - Style adjustments to needed to position utility nav links