### PR TITLE
Add _spacers.less to generate pad/mar utility classes

### DIFF
--- a/assets/app/styles/_spacers.less
+++ b/assets/app/styles/_spacers.less
@@ -1,0 +1,51 @@
+// Spacing utility classes
+// creates:
+//  .pad-sm, .pad-md, .pad-lg, etc
+//  .mar-sm, .mar-md, .mar-lg, etc
+//  .pad-left-sm, .mar-left-sm, etc
+//
+@nil: none 0 e('!important');
+// @auto 0 auto; is built into the fn below
+@xs: xs 3px e('');
+@sm: sm 5px e('');
+@md: md 10px e('');
+@lg: lg 15px e('');
+@xl: xl 20px e('');
+@xxl: xxl 30px e('');
+
+@sizes: @nil, @xs, @sm, @md, @lg, @xl, @xxl;
+@sides: top, right, bottom, left;
+
+.spacer-side(@list, @size, @px, @mod, @i:1) when (@i <= length(@list)) {
+  @side: extract(@list, @i);
+  .pad-@{side}-@{size} {
+    padding-@{side}: @px @mod;
+  }
+  .mar-@{side}-@{size} {
+    margin-@{side}: @px @mod;
+  }
+  .spacer-side(@list, @size, @px, @mod, @i+1);
+}
+
+.spacers(@list, @i:1) when (@i <= length(@list)) {
+  @item: extract(@list, @i);
+  @key: extract(@item, 1);
+  @val: extract(@item, 2);
+  @mod: extract(@item, 3);
+  .pad-auto-@{key} {
+    padding: 0 auto;
+  }
+  .mar-auto-@{key} {
+    margin: 0 auto;
+  }
+  .pad-@{key} {
+    padding: @val @val * 1.5;
+  }
+  .mar-@{key} {
+    margin: @val @val * 1.5;
+  }
+  .spacer-side(@sides, @key, @val, @mod);
+  .spacers(@list, @i+1);
+}
+
+.spacers(@sizes);

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -103,4 +103,5 @@
 @import "_tile.less";
 @import "_topology.less";
 @import "_typography.less";
+@import "_spacers.less";
 @import "_log.less";


### PR DESCRIPTION
Adds `_spacers.jess` to generate margin & padding utility classes

Discussion generated originally from [this PR](https://github.com/openshift/origin/pull/8180)

CSS output will look something like this:

```css
.pad-none{padding:0px}
 .mar-none{margin:0px}
 .pad-top-none{padding-top:0px!important}
 .mar-top-none{margin-top:0px!important}
 .pad-right-none{padding-right:0px!important}
 .mar-right-none{margin-right:0px!important}
 .pad-bottom-none{padding-bottom:0px!important}
 .mar-bottom-none{margin-bottom:0px!important}
 .pad-left-none{padding-left:0px!important}
 .mar-left-none{margin-left:0px!important}
 .pad-sm{padding:2px 4px}
 .mar-sm{margin:2px 4px}
 .pad-top-sm{padding-top:4px}
 .mar-top-sm{margin-top:4px}
 .pad-right-sm{padding-right:4px}
 .mar-right-sm{margin-right:4px}
 .pad-bottom-sm{padding-bottom:4px}
 .mar-bottom-sm{margin-bottom:4px}
 .pad-left-sm{padding-left:4px}
 .mar-left-sm{margin-left:4px}
 .pad-md{padding:4px 8px}
 .mar-md{margin:4px 8px}
 .pad-top-md{padding-top:8px}
 .mar-top-md{margin-top:8px}
 .pad-right-md{padding-right:8px}
 .mar-right-md{margin-right:8px}
 .pad-bottom-md{padding-bottom:8px}
 .mar-bottom-md{margin-bottom:8px}
 .pad-left-md{padding-left:8px}
 .mar-left-md{margin-left:8px}
 .pad-lg{padding:6px 12px}
 .mar-lg{margin:6px 12px}
 .pad-top-lg{padding-top:12px}
 .mar-top-lg{margin-top:12px}
 .pad-right-lg{padding-right:12px}
 .mar-right-lg{margin-right:12px}
 .pad-bottom-lg{padding-bottom:12px}
 .mar-bottom-lg{margin-bottom:12px}
 .pad-left-lg{padding-left:12px}
 .mar-left-lg{margin-left:12px}
 .pad-xl{padding:8px 16px}
 .mar-xl{margin:8px 16px}
 .pad-top-xl{padding-top:16px}
 .mar-top-xl{margin-top:16px}
 .pad-right-xl{padding-right:16px}
 .mar-right-xl{margin-right:16px}
 .pad-bottom-xl{padding-bottom:16px}
 .mar-bottom-xl{margin-bottom:16px}
 .pad-left-xl{padding-left:16px}
 .mar-left-xl{margin-left:16px}
 .pad-xxl{padding:16px 32px}
 .mar-xxl{margin:16px 32px}
 .pad-top-xxl{padding-top:32px}
 .mar-top-xxl{margin-top:32px}
 .pad-right-xxl{padding-right:32px}
 .mar-right-xxl{margin-right:32px}
 .pad-bottom-xxl{padding-bottom:32px}
 .mar-bottom-xxl{margin-bottom:32px}
 .pad-left-xxl{padding-left:32px}
 .mar-left-xxl{margin-left:32px}
```
Usage example:
```html
<div row reverse class="pad-md pad-left-none">
  <div flex class="pad-lg">Foo</div>
</div>
```


@jwforres @spadgett @rhamilto @sg00dwin breaking this out as a separate PR so we can discuss.  Items on the table:

- [x] Yay, will provide easy way to eliminate inline styles (cough, @rhamilto)
- [x] Is a simple consistent pattern that can be updated/extended by adjusting the `@sizes` or `@sides` list
- [x] Is consistent-ish with where Alpha bootstrap is going, though different naming convention & provides more options.  I expect Bootstrap will iterate on their naming 
- [x] is probably the same (or very close) as to what will land in `layout.attrs` in terms of naming, etc

Issues to address:
- [x] We use 5px, 10px throughout app, though have a variety of overrides/differences sprinkled around.  Would be good to normalize & ensure we set the `@sizes @sides` with the px vals we want to use.
- [x] Isn't exactly semantic, but is consistent w/bootstrap * layout.attrs methods of composable utilities

I think that sums up the discussion points to address.
