### PR TITLE
Web console: debug terminal for crashing pods

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -150,6 +150,7 @@
         <script src="scripts/services/routes.js"></script>
         <script src="scripts/services/charts.js"></script>
         <script src="scripts/services/hpa.js"></script>
+        <script src="scripts/services/pods.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
         <script src="scripts/controllers/pod.js"></script>
@@ -189,6 +190,7 @@
         <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
         <script src="scripts/controllers/modals/editModal.js"></script>
+        <script src="scripts/controllers/modals/debugTerminal.js"></script>
         <script src="scripts/controllers/about.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>

--- a/assets/app/scripts/controllers/modals/debugTerminal.js
+++ b/assets/app/scripts/controllers/modals/debugTerminal.js
@@ -8,16 +8,12 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('DebugTerminalModalController', function ($scope, $filter, $uibModalInstance, containerName) {
-    $scope.containerName = containerName;
+  .controller('DebugTerminalModalController', function ($scope, $filter, $uibModalInstance, container, image) {
+    $scope.container = container;
+    $scope.image = image;
     $scope.$watch('debugPod.status.containerStatuses', function() {
       $scope.containerState = _.get($scope, 'debugPod.status.containerStatuses[0].state');
     });
-
-    var imageID = _.get($scope, 'debugPod.spec.containers[0].image');
-    if (imageID) {
-      $scope.image = _.get($scope, ['imagesByDockerReference', imageID]);
-    }
     $scope.close = function() {
       $uibModalInstance.close('close');
     };

--- a/assets/app/scripts/controllers/modals/debugTerminal.js
+++ b/assets/app/scripts/controllers/modals/debugTerminal.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:DebugTerminalModalController
+ * @description
+ * # DebugTerminalModalController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('DebugTerminalModalController', function ($scope, $filter, $uibModalInstance, containerName) {
+    $scope.containerName = containerName;
+    $scope.$watch('debugPod.status.containerStatuses', function() {
+      $scope.containerState = _.get($scope, 'debugPod.status.containerStatuses[0].state');
+    });
+
+    var imageID = _.get($scope, 'debugPod.spec.containers[0].image');
+    if (imageID) {
+      $scope.image = _.get($scope, ['imagesByDockerReference', imageID]);
+    }
+    $scope.close = function() {
+      $uibModalInstance.close('close');
+    };
+  });

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -189,6 +189,7 @@ angular.module('openshiftConsole')
           // Create the debug pod.
           DataService.create("pods", null, debugPod, context).then(
             function(pod) {
+              var container = _.find($scope.pod.spec.containers, { name: containerName });
               $scope.debugPod = pod;
 
               // Watch the pod so we know when it's running to connect.
@@ -208,8 +209,11 @@ angular.module('openshiftConsole')
                 controller: 'DebugTerminalModalController',
                 scope: $scope,
                 resolve: {
-                  containerName: function() {
-                    return containerName;
+                  container: function() {
+                    return container;
+                  },
+                  image: function() {
+                    return _.get($scope, ['imagesByDockerReference', container.image]);
                   }
                 },
                 backdrop: 'static' // don't close modal when clicking backdrop

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -957,12 +957,48 @@ angular.module('openshiftConsole')
       return PodsService.getDebugLabel(pod);
     };
   })
+  // Determines the container entrypoint command from the container and docker image metadata.
   .filter('entrypoint', function() {
-    return function(image) {
-      if (!image) {
+    // If `cmd` is an array (exec form), converts it to a string for display.
+    var toShellForm = function(cmd) {
+      if (_.isArray(cmd)) {
+        return cmd.join(' ');
+      }
+
+      return cmd;
+    };
+
+    return function(container, image) {
+      if (!container || !image) {
         return null;
       }
 
-      return _.get(image, 'dockerImageMetadata.Config.Cmd', []).join(' ');
+      // http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments
+      var entrypoint,
+          cmd = toShellForm(container.command),
+          args = toShellForm(container.args);
+
+      // If `container.command` is specified, use that instead of image entrypoint. Add `container.args` if present.
+      if (cmd && args) {
+        return cmd + " " + args;
+      }
+
+      if (cmd) {
+        return cmd;
+      }
+
+      entrypoint = toShellForm(_.get(image, 'dockerImageMetadata.Config.Entrypoint') || ["/bin/sh", "-c"]);
+      // If `container.args` is supplied without `container.command`, use container args with the image entrypoint.
+      if (args) {
+        return entrypoint + " " + args;
+      }
+
+      // Otherwise, use container entrypoint with container command.
+      cmd = toShellForm(_.get(image, 'dockerImageMetadata.Config.Cmd'));
+      if (cmd) {
+        return entrypoint + " " + cmd;
+      }
+
+      return null;
     };
   });

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -278,9 +278,9 @@ angular.module('openshiftConsole')
   .filter('webhookURL', function(DataService) {
     return function(buildConfig, type, secret, project) {
       return DataService.url({
-      	// arbitrarily many subresources can be included
-      	// url encoding of the segments is handled by the url() function
-      	// subresource segments cannot contain '/'
+        // arbitrarily many subresources can be included
+        // url encoding of the segments is handled by the url() function
+        // subresource segments cannot contain '/'
         resource: "buildconfigs/webhooks/" + secret + "/" + type.toLowerCase(),
         name: buildConfig,
         namespace: project
@@ -950,5 +950,19 @@ angular.module('openshiftConsole')
       return _.every(containers, function(container) {
         return container.readinessProbe || container.livenessProbe;
       });
+    };
+  })
+  .filter('debugLabel', function(PodsService) {
+    return function(pod) {
+      return PodsService.getDebugLabel(pod);
+    };
+  })
+  .filter('entrypoint', function() {
+    return function(image) {
+      if (!image) {
+        return null;
+      }
+
+      return _.get(image, 'dockerImageMetadata.Config.Cmd', []).join(' ');
     };
   });

--- a/assets/app/scripts/services/pods.js
+++ b/assets/app/scripts/services/pods.js
@@ -1,0 +1,49 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("PodsService", function($filter) {
+    var getLabel = $filter('label');
+    var debugLabelKey = _.constant('debug.openshift.io/name');
+
+    return {
+      getDebugLabel: function(pod) {
+        return getLabel(pod, debugLabelKey());
+      },
+
+      // Generates a copy of pod for debugging crash loops.
+      generateDebugPod: function(pod, containerName) {
+        var container = _.find(pod.spec.containers, { name: containerName });
+        if (!container) {
+          return null;
+        }
+
+        // Copy the pod and make some changes for debugging. Use the same
+        // metadata as `oc debug`.
+        var debugPod = angular.copy(pod);
+        debugPod.metadata = {
+          name: pod.metadata.name + "-debug",
+          annotations: {
+            "debug.openshift.io/source-container": containerName,
+            "debug.openshift.io/source-resource": "pod/" + pod.metadata.name
+          },
+          labels: {}
+        };
+        debugPod.metadata.labels[debugLabelKey()] = pod.metadata.name;
+
+        // Never restart.
+        debugPod.spec.restartPolicy = "Never";
+        debugPod.status = {};
+        delete container.readinessProbe;
+        delete container.livenessProbe;
+
+        // Prevent container from stopping immediately.
+        container.command = ['sleep'];
+        // Sleep for one hour. This will cause the container to stop after one
+        // hour if for some reason the pod is not deleted.
+        container.args = ['' + (60 * 60)];
+        debugPod.spec.containers = [container];
+
+        return debugPod;
+      }
+    };
+  });

--- a/assets/app/scripts/services/pods.js
+++ b/assets/app/scripts/services/pods.js
@@ -12,14 +12,14 @@ angular.module("openshiftConsole")
 
       // Generates a copy of pod for debugging crash loops.
       generateDebugPod: function(pod, containerName) {
-        var container = _.find(pod.spec.containers, { name: containerName });
+        // Copy the pod and make some changes for debugging.
+        var debugPod = angular.copy(pod);
+        var container = _.find(debugPod.spec.containers, { name: containerName });
         if (!container) {
           return null;
         }
 
-        // Copy the pod and make some changes for debugging. Use the same
-        // metadata as `oc debug`.
-        var debugPod = angular.copy(pod);
+        // Use the same metadata as `oc debug`.
         debugPod.metadata = {
           name: pod.metadata.name + "-debug",
           annotations: {

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -196,7 +196,7 @@
 }
 
 .empty-state-message {
-  margin: 60px auto @grid-gutter-width;
+  margin: 60px auto;
   max-width: 600px;
   padding: 0 (@grid-gutter-width / 2);
   .btn {
@@ -884,6 +884,35 @@ a.disabled-link {
   }
 }
 
+.debug-pod-action {
+  margin-top: 5px;
+}
+
+.modal-debug-terminal {
+  .modal-header {
+    padding: 0 18px 5px;
+    h2 {
+      margin-bottom: 5px;
+    }
+  }
+  .modal-body {
+    border-top: 1px solid #bbbbbb;
+    border-bottom: 1px solid #bbbbbb;
+    padding: 5px 15px 0;
+    .original-cmd-msg {
+      margin-bottom: 10px;
+    }
+    kubernetes-container-terminal {
+      .text-center();
+      overflow: hidden;
+    }
+    padding-bottom: 15px;
+  }
+  .modal-footer {
+    padding-top: 0;
+  }
+}
+
 .dockerfile-editor {
   height: 200px;
 }
@@ -1043,7 +1072,8 @@ h1 small.meta, .build-config-summary .meta {
   white-space: pre-wrap;
 }
 
-.warnings-popover {
+.info-popover, .warnings-popover {
   cursor: help;
   vertical-align: middle;
+  margin-left: 2px;
 }

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -62,8 +62,7 @@
           <dd>{{containerStatus.ready}}</dd>
           <dt>Restart Count:</dt>
           <dd>{{containerStatus.restartCount}}</dd>
-          <div class="debug-pod-action">
-          <!-- <div ng-if="(!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel)" class="debug-pod-action"> -->
+          <div ng-if="(!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel)" class="debug-pod-action">
             <a href="" ng-click="debugTerminal(containerStatus.name)" role="button">Debug in terminal</a>
           </div>
         </dl>

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -1,7 +1,13 @@
 <div class="resource-details">
   <div class="row">
     <div class="col-lg-6">
-      <h3>Status</h3>
+      <h3>
+        Status
+        <small ng-if="pod | debugLabel">
+          debugging
+          <a ng-href="{{pod | debugLabel | navigateResourceURL : 'Pod' : pod.metadata.namespace}}">{{pod | debugLabel}}</a>
+        </small>
+      </h3>
       <dl class="dl-horizontal left">
         <dt>Status:</dt>
         <dd>
@@ -56,6 +62,10 @@
           <dd>{{containerStatus.ready}}</dd>
           <dt>Restart Count:</dt>
           <dd>{{containerStatus.restartCount}}</dd>
+          <div class="debug-pod-action">
+          <!-- <div ng-if="(!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel)" class="debug-pod-action"> -->
+            <a href="" ng-click="debugTerminal(containerStatus.name)" role="button">Debug in terminal</a>
+          </div>
         </dl>
       </div>
     </div>

--- a/assets/app/views/modals/debug-terminal.html
+++ b/assets/app/views/modals/debug-terminal.html
@@ -1,0 +1,47 @@
+<div class="modal-debug-terminal">
+  <div class="modal-header">
+    <h2>Debug Container {{containerName}}</h2>
+    <small class="text-muted">
+      {{debugPod.metadata.name}} &mdash;
+      <status-icon status="debugPod | podStatus"></status-icon>
+      {{debugPod | podStatus | sentenceCase}}
+    </small>
+  </div>
+  <div class="modal-body">
+    <div ng-if="!containerState.running" class="empty-state-message text-center">
+      <!-- Waiting for debug container to start. -->
+      <h2 ng-if="debugPod.status.phase !== 'Failed'" class="text-muted">
+        Waiting for container {{containerName}} to start...
+      </h2>
+      <!-- Debug container failed. -->
+      <div ng-if="debugPod.status.phase === 'Failed'">
+        <h2>
+          <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
+          Could not start container {{containerName}}.
+        </h2>
+        <p>
+          An error occurred starting the debug pod.
+          <span ng-if="containerState.terminated.message">{{containerState.terminated.message}}</span>
+          <span ng-if="containerState.terminated.exitCode" class="text-muted">Exit code: {{containerState.terminated.exitCode}}</span>
+        </p>
+      </div>
+    </div>
+    <!-- Debug container running. -->
+    <div ng-if="containerState.running">
+      <div class="alert alert-info">
+        <span class="pficon pficon-info" aria-hidden="true"></span>
+        This temporary pod has a modified entrypoint command to debug a failing container. The pod
+        will be deleted when the terminal is closed or after one hour.
+      </div>
+      <div ng-if="image | entrypoint" class="original-cmd-msg">
+        <label>Original Command:</label>
+        <code>{{image | entrypoint}}</code>
+        <copy-to-clipboard-button clipboard-text="image | entrypoint"></copy-to-clipboard-button>
+      </div>
+      <kubernetes-container-terminal pod="debugPod" container="containerName"></kubernetes-container-terminal>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-lg btn-primary" type="button" ng-click="close()">Close</button>
+  </div>
+</div>

--- a/assets/app/views/modals/debug-terminal.html
+++ b/assets/app/views/modals/debug-terminal.html
@@ -1,6 +1,6 @@
 <div class="modal-debug-terminal">
   <div class="modal-header">
-    <h2>Debug Container {{containerName}}</h2>
+    <h2>Debug Container {{container.name}}</h2>
     <small class="text-muted">
       {{debugPod.metadata.name}} &mdash;
       <status-icon status="debugPod | podStatus"></status-icon>
@@ -11,13 +11,13 @@
     <div ng-if="!containerState.running" class="empty-state-message text-center">
       <!-- Waiting for debug container to start. -->
       <h2 ng-if="debugPod.status.phase !== 'Failed'" class="text-muted">
-        Waiting for container {{containerName}} to start...
+        Waiting for container {{container.name}} to start...
       </h2>
       <!-- Debug container failed. -->
       <div ng-if="debugPod.status.phase === 'Failed'">
         <h2>
           <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
-          Could not start container {{containerName}}.
+          Could not start container {{container.name}}.
         </h2>
         <p>
           An error occurred starting the debug pod.
@@ -28,17 +28,17 @@
     </div>
     <!-- Debug container running. -->
     <div ng-if="containerState.running">
-      <div class="alert alert-info">
-        <span class="pficon pficon-info" aria-hidden="true"></span>
+      <div class="help-block">
         This temporary pod has a modified entrypoint command to debug a failing container. The pod
         will be deleted when the terminal is closed or after one hour.
       </div>
-      <div ng-if="image | entrypoint" class="original-cmd-msg">
+      <div ng-if="container | entrypoint : image" class="original-cmd-msg">
         <label>Original Command:</label>
-        <code>{{image | entrypoint}}</code>
-        <copy-to-clipboard-button clipboard-text="image | entrypoint"></copy-to-clipboard-button>
+        <code>{{container | entrypoint : image}}</code>
+        <!-- Don't add the copy-to-clipboard button for now since we have problems with paste in the terminal. -->
+        <!-- <copy-to-clipboard-button clipboard-text="container | entrypoint : image"></copy-to-clipboard-button> -->
       </div>
-      <kubernetes-container-terminal pod="debugPod" container="containerName"></kubernetes-container-terminal>
+      <kubernetes-container-terminal pod="debugPod" container="container.name"></kubernetes-container-terminal>
     </div>
   </div>
   <div class="modal-footer">

--- a/assets/app/views/pods.html
+++ b/assets/app/views/pods.html
@@ -41,6 +41,14 @@
                       <span ng-if="pod | isTroubledPod">
                         <pod-warnings pod="pod"></pod-warnings>
                       </span>
+                      <span ng-if="pod | debugLabel">
+                        <i class="fa fa-bug info-popover"
+                           aria-hidden="true"
+                           data-toggle="popover"
+                           data-trigger="hover"
+                           dynamic-content="Debugging pod {{pod | debugLabel}}"></i>
+                         <span class="sr-only">Debugging pod {{pod | debugLabel}}</span>
+                      </span>
                     </td>
                     <td data-title="Status">
                       <div row class="status">

--- a/assets/test/spec/filters/entrypointSpec.js
+++ b/assets/test/spec/filters/entrypointSpec.js
@@ -1,0 +1,86 @@
+"use strict";
+
+describe('entrypointFilter', function(){
+  var entrypoint, container, image;
+  beforeEach(inject(function(entrypointFilter) {
+    entrypoint = entrypointFilter;
+
+    // Only `command` and `args` are looked at by the filter, which we set below for some tests.
+    container = {};
+
+    // Only `dockerImageMetadata.Config.Entrypoint` and `dockerImageMetadata.Config.Cmd` are looked at by the filter.
+    image = {
+      dockerImageMetadata: {
+        Config: {
+          Cmd: [
+            '/usr/libexec/s2i/run'
+          ],
+          Entrypoint: [
+            "container-entrypoint"
+          ],
+        }
+      }
+    };
+  }));
+
+  it('should return null if container or image are not specified', function() {
+    expect(entrypoint(null, null)).toBeNull();
+    expect(entrypoint(container, null)).toBeNull();
+    expect(entrypoint(null, image)).toBeNull();
+  });
+
+  it('should return null if no entrypoint', function() {
+    expect(entrypoint({}, {})).toBeNull();
+  });
+
+  it('should return the container command if defined in exec form', function() {
+    container.command = ['sleep', '100'];
+    expect(entrypoint(container, image)).toBe('sleep 100');
+  });
+
+  it('should return the container command if defined in shell form', function() {
+    container.command = 'sleep 100';
+    expect(entrypoint(container, image)).toBe('sleep 100');
+  });
+
+  it('should return the container command and args if defined in exec form', function() {
+    container.command = ['/bin/sh', '-c'];
+    container.args = ['echo', 'hello'];
+    expect(entrypoint(container, image)).toBe('/bin/sh -c echo hello');
+  });
+
+  it('should return the container command and args if defined in shell form', function() {
+    container.command =  '/bin/sh -c';
+    container.args = 'echo hello';
+    expect(entrypoint(container, image)).toBe('/bin/sh -c echo hello');
+  });
+
+  it('should return the image entrypoint and cmd if specified in exec form', function() {
+    expect(entrypoint({}, image)).toBe('container-entrypoint /usr/libexec/s2i/run');
+  });
+
+  it('should return the image entrypoint and cmd if specified in shell form', function() {
+    image.dockerImageMetadata.Config.Entrypoint = 'container-entrypoint';
+    image.dockerImageMetadata.Config.Cmd = '/usr/libexec/s2i/run';
+    expect(entrypoint({}, image)).toBe('container-entrypoint /usr/libexec/s2i/run');
+  });
+
+  it('should return the image entrypoint and cmd if specified in shell form', function() {
+    expect(entrypoint({}, image)).toBe('container-entrypoint /usr/libexec/s2i/run');
+  });
+
+  it('should return the image entrypoint and container args if specified in exec form', function() {
+    container.args = ['echo', 'hello'];
+    expect(entrypoint(container, image)).toBe('container-entrypoint echo hello');
+  });
+
+  it('should return the image entrypoint and container args if specified in shell form', function() {
+    container.args = 'echo hello';
+    expect(entrypoint(container, image)).toBe('container-entrypoint echo hello');
+  });
+
+  it('should default entrypoint to /bin/sh -c', function() {
+    image.dockerImageMetadata.Config.Entrypoint = null;
+    expect(entrypoint(container, image)).toBe('/bin/sh -c /usr/libexec/s2i/run');
+  });
+});


### PR DESCRIPTION
https://trello.com/c/y5ox6pQr

Starts a debug pod that runs a different command to prevent the container crashing and opens a terminal window.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/14183298/8f15e2ac-f73d-11e5-88e3-226c64be8731.png)

TODO:

- [x] Align behavior with `oc debug`
  - [x] Use same debug pod name
  - [x] Disable readiness and liveness probes by default
  - [x] Remove annotations by default
- [x] Show help text
- [x] Try to delete pod if user navigates away without closing modal
- [x] Rebase for 1.3 branch
- [x] Detect container errors when waiting for container to start in debug dialog
- [x] Show container status when waiting for container to start
- [x] Don't show debug link in browse pod page for debug pods :)
- [x] Hard delete debug pod (no grace period)

Replaces https://github.com/openshift/origin/pull/7305