### PR TITLE
Update online extensions, avoid rendering emtpy DOM nodes

### DIFF
--- a/assets/extensions/examples/online-extensions.js
+++ b/assets/extensions/examples/online-extensions.js
@@ -35,18 +35,17 @@ window.OPENSHIFT_CONSTANTS.HELP = {
 
 
 angular
-  .module('openshiftConsoleExtensions')
+  .module('openshiftOnlineExtensions', ['openshiftConsole'])
   .run([
     'extensionRegistry',
     function(extensionRegistry) {
 
-      var system_status_elem = $('<a href="http://status.openshift.com/" target="_blank" class="nav-item-iconic system-status project-action-btn" style="display: none;">');
-      var system_status_elem_mobile = $('<div row flex class="navbar-flex-btn system-status-mobile" style="display: none;">');
+      var system_status_elem = $('<a href="http://status.openshift.com/" target="_blank" class="nav-item-iconic system-status project-action-btn">');
+      var system_status_elem_mobile = $('<div row flex class="navbar-flex-btn system-status-mobile">');
 
 
       $.getJSON("https://m0sg3q4t415n.statuspage.io/api/v2/summary.json", function (data) {
         var n = (data.incidents || [ ]).length;
-        n = 32;
         if (n > 0) {
           var issueStr = n + ' open issue';
           if (n !== 1) {
@@ -54,31 +53,29 @@ angular
           }
           $('<span title="System Status" class="fa status-icon pficon-warning-triangle-o"></span>').appendTo(system_status_elem);
           $('<span class="status-issue">' + issueStr + '</span>').appendTo(system_status_elem);
-          system_status_elem.css('display', '');
 
           system_status_elem_mobile.append(system_status_elem.clone());
-          system_status_elem_mobile.css('display', '');
+
+          // only add the extension if there is something to show so we
+          // do not generate empty nodes if no issues
+          extensionRegistry
+            .add('nav-system-status', function() {
+              return [{
+                type: 'dom',
+                node: system_status_elem
+              }];
+            });
+
+          extensionRegistry
+            .add('nav-system-status-mobile', function() {
+              return [{
+                type: 'dom',
+                node: system_status_elem_mobile
+              }];
+            });
+
         }
       });
-
-
-      extensionRegistry
-        .add('nav-system-status', function() {
-          return [{
-            type: 'dom',
-            node: system_status_elem
-          }];
-        });
-
-
-      extensionRegistry
-        .add('nav-system-status-mobile', function() {
-          return [{
-            type: 'dom',
-            node: system_status_elem_mobile
-          }];
-        });
-
 
       extensionRegistry
         .add('nav-help-dropdown', function() {
@@ -101,3 +98,5 @@ angular
 
     }
   ]);
+
+hawtioPluginLoader.addModule('openshiftOnlineExtensions');


### PR DESCRIPTION
- Fix issue #8262 by not rendering empty DOM nodes with extension
- Fix issue #8290 (no longer applicable, simplified solution for above fix)
(I don't think the comment here will auto-close across forks)

Tinkered with potential updates with the extension manager, then realized the right fix is to encourage extensions to be responsible & not render DOM if there is nothing meaningful to add.  Checking for empty child nodes (or grandchild, etc etc) did not seem like the appropriate fix & getting the extension-manager to publish # of rendered extensions would also not solve the problem.  The `:empty` css fix was not a solution either as child nodes could exist but be empty (as stated previously).

- Decided to make this its own module `openshiftOnlineExtensions ` since it is completely unrelated to our bundled extension & we don't have to worry about collisions.

@jwforres @spadgett @sg00dwin


