### PR TITLE
Update grunt-contrib-jshintrc to 1.0.0

### DIFF
--- a/assets/.jshintrc
+++ b/assets/.jshintrc
@@ -9,7 +9,7 @@
   "expr" : true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": "nofunc",
   "newcap": false,
   "noarg": true,
   "quotmark": false,

--- a/assets/package.json
+++ b/assets/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-cssmin": "0.14.0",
     "grunt-contrib-htmlmin": "0.6.0",
     "grunt-contrib-imagemin": "0.8.1",
-    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-jshint": "1.0.0",
     "grunt-contrib-less": "1.0.0",
     "grunt-contrib-uglify": "0.6.0",
     "grunt-contrib-watch": "0.6.1",


### PR DESCRIPTION
@jwforres I was seeing differences running jshint locally compared to grunt since we're on a pretty old version. This bumps it to the latest. Needed to update `latedef`, which now complains about function declarations after they're first called.

http://jshint.com/docs/options/#latedef