### PR TITLE
Fix jshint warnings

### DIFF
--- a/assets/app/scripts/controllers/attachPVC.js
+++ b/assets/app/scripts/controllers/attachPVC.js
@@ -155,7 +155,7 @@ angular.module('openshiftConsole')
         };
 
         // breadcrumb must react depending on what we are attaching to (deployment or dc)
-        var rebuildBreadcrumb = function() {
+        function rebuildBreadcrumb() {
           $scope.breadcrumbs.splice(1, 0, {
             title: "Deployments",
             link: "project/" + $routeParams.project + "/browse/deployments"
@@ -184,7 +184,7 @@ angular.module('openshiftConsole')
               });
             }
           }
-        };
+        }
 
         validateRouteParams();
         load();

--- a/assets/app/scripts/controllers/deployment.js
+++ b/assets/app/scripts/controllers/deployment.js
@@ -118,7 +118,7 @@ angular.module('openshiftConsole')
         };
 
         var allHPA = {}, limitRanges = {};
-        var updateHPA = function() {
+        function updateHPA() {
           $scope.hpaForRC = HPAService.hpaForRC(allHPA, $routeParams.deployment || $routeParams.replicationcontroller);
           if ($scope.isActive) {
             // Show both HPAs that target the RC and the DC if this is the active deployment.
@@ -127,7 +127,7 @@ angular.module('openshiftConsole')
           } else {
             $scope.autoscalers = $scope.hpaForRC;
           }
-        };
+        }
         var updateHPAWarnings = function() {
             HPAService.getHPAWarnings($scope.deployment, $scope.autoscalers, limitRanges, project)
                       .then(function(warnings) {

--- a/assets/app/scripts/controllers/projects.js
+++ b/assets/app/scripts/controllers/projects.js
@@ -72,10 +72,10 @@ angular.module('openshiftConsole')
       }
     });
 
-    var loadProjects = function() {
+    function loadProjects() {
       DataService.list("projects", $scope, function(projects) {
         $scope.projects = projects.by("metadata.name");
         $scope.showGetStarted = hashSizeFilter($scope.projects) === 0;
       });
-    };
+    }
   });

--- a/assets/app/scripts/services/api.js
+++ b/assets/app/scripts/services/api.js
@@ -41,7 +41,7 @@ ResourceGroupVersion.prototype.equals = function(resource, group, version) {
 
 angular.module('openshiftConsole')
 .factory('APIService', function(API_CFG, APIS_CFG, Logger) {
-  
+
   // Set the default api versions the console will use if otherwise unspecified
   var defaultVersion = {
     "":           "v1",
@@ -74,9 +74,9 @@ angular.module('openshiftConsole')
     }
     return new ResourceGroupVersion(resource, group, version);
   };
-  
+
   // normalizeResource lowercases the first segment of the given resource. subresources can be case-sensitive.
-  var normalizeResource = function(resource) {
+  function normalizeResource(resource) {
     if (!resource) {
       return resource;
     }
@@ -85,8 +85,8 @@ angular.module('openshiftConsole')
       return resource.toLowerCase();
     }
     return resource.substring(0, i).toLowerCase() + resource.substring(i);
-  };
-  
+  }
+
   // port of group_version.go#ParseGroupVersion
   var parseGroupVersion = function(apiVersion) {
     if (!apiVersion) {
@@ -102,7 +102,7 @@ angular.module('openshiftConsole')
     Logger.warn('Invalid apiVersion "' + apiVersion + '"');
     return undefined;
   };
-  
+
   var objectToResourceGroupVersion = function(apiObject) {
     if (!apiObject || !apiObject.kind || !apiObject.apiVersion) {
       return undefined;
@@ -117,7 +117,7 @@ angular.module('openshiftConsole')
     }
     return new ResourceGroupVersion(resource, groupVersion.group, groupVersion.version);
   };
-  
+
   // deriveTargetResource figures out the fully qualified destination to submit the object to.
   // if resource is a string, and the object's kind matches the resource, the object's group/version are used.
   // if resource is a ResourceGroupVersion, and the object's kind and group match, the object's version is used.
@@ -132,7 +132,7 @@ angular.module('openshiftConsole')
     if (!objectResource || !objectGroupVersion || !resourceGroupVersion) {
       return undefined;
     }
-    
+
     // We specified something like "pods"
     if (angular.isString(resource)) {
       // If the object had a matching kind {"kind":"Pod","apiVersion":"v1"}, use the group/version from the object
@@ -142,17 +142,17 @@ angular.module('openshiftConsole')
       }
       return resourceGroupVersion;
     }
-    
+
     // If the resource was already a fully specified object,
     // require the group to match as well before taking the version from the object
     if (resourceGroupVersion.equals(objectResource, objectGroupVersion.group)) {
       resourceGroupVersion.version = objectGroupVersion.version;
     }
     return resourceGroupVersion;
-  };  
-  
+  };
+
   // port of restmapper.go#kindToResource
-  var kindToResource = function(kind) {
+  function kindToResource(kind) {
     if (!kind) {
       return "";
     }
@@ -171,14 +171,14 @@ angular.module('openshiftConsole')
     }
 
     return resource;
-  };
-  
+  }
+
   // apiInfo returns the host/port, prefix, group, and version for the given resource,
   // or undefined if the specified resource/group/version is known not to exist.
   var apiInfo = function(resource) {
     resource = toResourceGroupVersion(resource);
     var primaryResource = resource.primaryResource();
-    
+
     // API info for resources in an API group can just be derived
     // TODO: use API discovery to determine available groups, versions, and resources
     // If this is called before discovery loads, just return the derived data, but if we know from discovery that a group/version/resource is invalid, return undefined.
@@ -190,7 +190,7 @@ angular.module('openshiftConsole')
         version:  resource.version
       };
     }
-    
+
     // Resources without an API group could be legacy k8s or origin resources.
     // Scan through resources to determine which this is.
     var api, prefix;
@@ -210,8 +210,8 @@ angular.module('openshiftConsole')
       };
     }
     return undefined;
-  };  
-  
+  };
+
   var invalidObjectKindOrVersion = function(apiObject) {
     var kind = "<none>";
     var version = "<none>";
@@ -226,20 +226,20 @@ angular.module('openshiftConsole')
     if (apiObject && apiObject.apiVersion) { version = apiObject.apiVersion; }
     return "The API version "+version+" for kind " + kind + " is not supported by this server";
   };
-    
+
   return {
     toResourceGroupVersion: toResourceGroupVersion,
-    
+
     parseGroupVersion: parseGroupVersion,
-    
+
     objectToResourceGroupVersion: objectToResourceGroupVersion,
-    
+
     deriveTargetResource: deriveTargetResource,
-    
+
     kindToResource: kindToResource,
-    
+
     apiInfo: apiInfo,
-    
+
     invalidObjectKindOrVersion: invalidObjectKindOrVersion,
     unsupportedObjectKindOrVersion: unsupportedObjectKindOrVersion
   };

--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -38,7 +38,7 @@ angular.module('openshiftConsole')
   // Handles attr with dot notation
   // TODO write lots of tests for this helper
   // Note: this lives outside the Data prototype for now so it can be used by the helper in DataService as well
-  var _objectByAttribute = function(obj, attr, map, action) {
+  function _objectByAttribute(obj, attr, map, action) {
     var subAttrs = attr.split(".");
     var attrValue = obj;
     for (var i = 0; i < subAttrs.length; i++) {
@@ -73,7 +73,7 @@ angular.module('openshiftConsole')
         map[attrValue] = obj;
       }
     }
-  };
+  }
 
   function DataService() {
     this._listCallbacksMap = {};


### PR DESCRIPTION
Use function declarations rather than function expressions when a function is called before defined. This can prevent runtime errors.

(The newer jshint is catching these problems.)

@jwforres PTAL