### PR TITLE
Warn users when navigating away with the terminal window open

### DIFF
--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -158,6 +158,8 @@ angular.module('openshiftConsole')
             debugPodWatch = null;
           }
 
+          $(window).off('beforeunload.debugPod');
+
           if (debugPod) {
             DataService.delete("pods", debugPod.metadata.name, context, {
               gracePeriodSeconds: 0
@@ -191,6 +193,11 @@ angular.module('openshiftConsole')
             function(pod) {
               var container = _.find($scope.pod.spec.containers, { name: containerName });
               $scope.debugPod = pod;
+
+              // Warn users when navigating away with the debug pod open. (Removed in `cleanUpDebugPod`.)
+              $(window).on('beforeunload.debugPod', function() {
+                return "Are you sure you want to leave with the debug terminal open? The debug pod will not be deleted unless you close the dialog.";
+              });
 
               // Watch the pod so we know when it's running to connect.
               // Keep the watch handle in a var outside the watches array so we

--- a/assets/app/views/modals/debug-terminal.html
+++ b/assets/app/views/modals/debug-terminal.html
@@ -30,7 +30,7 @@
     <div ng-if="containerState.running">
       <div class="help-block">
         This temporary pod has a modified entrypoint command to debug a failing container. The pod
-        will be deleted when the terminal is closed or after one hour.
+        will be available for one hour and will be deleted when the terminal window is closed.
       </div>
       <div ng-if="container | entrypoint : image" class="original-cmd-msg">
         <label>Original Command:</label>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1325761

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/14430262/d763481c-ffce-11e5-93bd-0a047d147a0d.png)

Browser support for `onbeforeunload`: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload

@jwforres PTAL