### PR TITLE
Enforce overview scaling rules for deployments without a service

### DIFF
--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -239,7 +239,7 @@
                       deployment-config-id="deploymentConfigId"
                       deployment-config-missing="deploymentConfigs && !deploymentConfigs[deploymentConfigId]"
                       deployment-config-different-service="deploymentConfigs[deploymentConfigId] && !deploymentConfigsByService[''][deploymentConfigId]"
-                      scalable="true"
+                      scalable="isScalable(deployment, deploymentConfigId)"
                       hpa="getHPA(deployment.metadata.name, deploymentConfigId)"
                       limit-ranges="limitRanges"
                       project="project"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1326214

@jwforres PTAL. The browse deployment page doesn't have this problem, only the overview.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/14462820/c13b224e-0096-11e6-8c8e-99798e28c168.png)
