### PR TITLE
Hide empty nodes

### DIFF
--- a/assets/app/styles/_utils.less
+++ b/assets/app/styles/_utils.less
@@ -1,0 +1,18 @@
+// hides the node if it has no children.
+// https://css-tricks.com/almanac/selectors/e/empty/
+// - will match the following:
+//     <div></div>
+//   or:
+//     <div><!-- nothing here --></div>
+// - will not match:
+//     <div> </div>
+//   or:
+//     <div>
+//       <!-- test -->
+//     </div>
+//   or:
+//     <div>
+//     </div>
+.hide-if-empty:empty {
+  display: none !important;
+}

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -106,3 +106,4 @@
 @import "_spacers.less";
 @import "_log.less";
 @import "_settings.less";
+@import "_utils.less";

--- a/assets/app/views/directives/header/default-header.html
+++ b/assets/app/views/directives/header/default-header.html
@@ -23,7 +23,7 @@
       extension-point
       extension-name="nav-system-status-mobile"
       extension-types="dom"
-      class="navbar-flex-btn"></div>
+      class="navbar-flex-btn hide-if-empty"></div>
 
   </div>
 </nav>

--- a/assets/app/views/directives/header/project-header.html
+++ b/assets/app/views/directives/header/project-header.html
@@ -29,7 +29,7 @@
         extension-point
         extension-name="nav-system-status-mobile"
         extension-types="dom"
-        class="navbar-flex-btn"></div>
+        class="navbar-flex-btn hide-if-empty"></div>
 
     </div>
   </div> <!-- /navbar-project-menu -->


### PR DESCRIPTION
It looks like the `:empty` selector to hide the online mobile extension was swallowed somewhere.  This PR:

- Reintroduce :empty selector to hide online extensions but adds as a util class, adds directive to do the same programmatically:

Can do this:
```html
<div class="hide-if-empty"> </div>
```
or:
```html
<div hide-if-empty> </div>
<div hide-if-empty="include comments"><!-- a comment will keep parent visible --></div>
```



