### PR TITLE
Update nav-mobile-dropdown to use new extensions

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -252,6 +252,9 @@
 
         <!-- add bundled extensions here -->
         <script src="scripts/extensions/javalink/javaLink.js"></script>
+        <script src="scripts/extensions/nav/helpDropdown.js"></script>
+        <script src="scripts/extensions/nav/userDropdown.js"></script>
+        <script src="scripts/extensions/nav/dropdownMobile.js"></script>
         <!-- endbuild -->
 
     <!-- Load any extensions last. -->

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -348,30 +348,6 @@ angular
         return durationFilter(timestamp, null, omitSingle, precision) || existing;
       });
     }, 1000);
-  })
-  // prepopulating extension points with some of our own data
-  // (ensures a single interface for extending the UI)
-  .run(function(extensionRegistry) {
-    extensionRegistry
-      .add('nav-help-dropdown', function() {
-        return [
-          {
-            type: 'dom',
-            node: '<li><a href="https://docs.openshift.org/latest/welcome/index.html">Documentation</a></li>'
-          },
-          {
-            type: 'dom',
-            node: '<li><a href="about">About</a></li>'
-          }
-        ];
-      });
-    extensionRegistry
-      .add('nav-user-dropdown', function() {
-        return [{
-          type: 'dom',
-          node: '<li><a href="logout">Log out</a></li>'
-        }];
-      });
   });
 
 hawtioPluginLoader.addModule('openshiftConsole');

--- a/assets/app/scripts/extensions/nav/dropdownMobile.js
+++ b/assets/app/scripts/extensions/nav/dropdownMobile.js
@@ -1,0 +1,37 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .run(function(extensionRegistry) {
+    extensionRegistry
+      .add('nav-dropdown-mobile', _.spread(function(user) {
+        return [{
+          type: 'dom',
+          node: [
+            '<li>',
+              '<a href="https://docs.openshift.org/latest/welcome/index.html">',
+                '<span class="fa fa-book fa-fw" aria-hidden="true"></span> Documentation',
+              '</a>',
+            '</li>'
+          ].join('')
+        }, {
+          type: 'dom',
+          node: [
+            '<li>',
+              '<a href="about">',
+                '<span class="pficon pficon-info fa-fw" aria-hidden="true"></span> About',
+              '</a>',
+            '</li>'
+          ].join('')
+        }, {
+          type: 'dom',
+          node: _.template([
+            '<li>',
+              '<a href="logout">',
+                '<span class="pficon pficon-user fa-fw" aria-hidden="true"></span>',
+                'Log out <span class="username"><%= userName %></span>',
+              '</a>',
+            '</li>'
+          ].join(''))({userName: user.fullName || user.metadata.name })
+        }];
+      }));
+  });

--- a/assets/app/scripts/extensions/nav/helpDropdown.js
+++ b/assets/app/scripts/extensions/nav/helpDropdown.js
@@ -1,0 +1,20 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  // prepopulating extension points with some of our own data
+  // (ensures a single interface for extending the UI)
+  .run(function(extensionRegistry) {
+    extensionRegistry
+      .add('nav-help-dropdown', function() {
+        return [
+          {
+            type: 'dom',
+            node: '<li><a href="https://docs.openshift.org/latest/welcome/index.html">Documentation</a></li>'
+          },
+          {
+            type: 'dom',
+            node: '<li><a href="about">About</a></li>'
+          }
+        ];
+      });
+  });

--- a/assets/app/scripts/extensions/nav/userDropdown.js
+++ b/assets/app/scripts/extensions/nav/userDropdown.js
@@ -1,0 +1,12 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .run(function(extensionRegistry) {
+    extensionRegistry
+      .add('nav-user-dropdown', function() {
+        return [{
+          type: 'dom',
+          node: '<li><a href="logout">Log out</a></li>'
+        }];
+      });
+  });

--- a/assets/app/views/directives/header/_navbar-utility-mobile.html
+++ b/assets/app/views/directives/header/_navbar-utility-mobile.html
@@ -1,20 +1,8 @@
 <nav class="navbar navbar-sidebar visible-xs-block">
-  <ul class="nav nav-sidenav-primary" hawtio-extension name="nav-mobile-dropdown">
-    <li>
-      <a href="https://docs.openshift.org/latest/welcome/index.html">
-        <span class="fa fa-book fa-fw" aria-hidden="true"></span> Documentation
-      </a>
-    </li>
-    <li>
-      <a href="about">
-        <span class="pficon pficon-info fa-fw" aria-hidden="true"></span> About
-      </a>
-    </li>
-    <li>
-      <a href="logout">
-        <span class="pficon pficon-user fa-fw" aria-hidden="true"></span>
-        Log out <span class="username">{{user.fullName || user.metadata.name}}</span>
-      </a>
-    </li>
-  </ul>
+  <ul
+    extension-point
+    extension-name="nav-dropdown-mobile"
+    extension-types="dom"
+    extension-args="[user]"
+    class="nav nav-sidenav-primary"></ul>
 </nav>


### PR DESCRIPTION
Saw that we had `nav-mobile-dropdown` lingering under the old hawtio extension, though I'm not sure if it was in use.  This PR udpates it to the new angular-extension-point to be consistent with the rest of our extensions.  

A new `.run()` block is introduced to keep each extension isolated (since they are pre-populated).  I may break these out into a separate file rather than continually adding to `app.js`.  Thinking about adding additional directories to `/scripts/extensions/`. 