### PR TITLE
No input bc

### DIFF
--- a/assets/app/scripts/controllers/edit/buildConfig.js
+++ b/assets/app/scripts/controllers/edit/buildConfig.js
@@ -93,7 +93,8 @@ angular.module('openshiftConsole')
       "dockerfile": false,
       "git": false,
       "images": false,
-      "contextDir": false
+      "contextDir": false,
+      "none": true
     };
     // $scope.triggers.present.imageChange points to builder imageChange trigger.
     $scope.triggers = {
@@ -808,6 +809,10 @@ angular.module('openshiftConsole')
     };
 
     $scope.getSourceMap = function(sourceMap, sources) {
+      if (sources.type === "None") {
+        return sourceMap
+      }
+      sourceMap.none = false;
       angular.forEach(sources, function(value, key) {
         sourceMap[key] = true;
       });

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -268,6 +268,18 @@
                                     }" readonly ng-model="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline ace-read-only mar-top-md"></div>
                                   </div>
                                 </div>
+                                <div ng-if="buildConfig.spec.source.type == 'None'">
+                                  <dt>Source:</dt>
+                                  <dd>
+                                    <i>none</i>
+                                    <span class="help action-inline">
+                                      <a href>
+                                        <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="No source inputs have been defined for this build configuration.">
+                                        </i>
+                                      </a>
+                                    </span>
+                                  </dd>
+                                </div>
                                 <div ng-if="buildConfig.spec.source.images" class="image-sources">
                                   <dt>Image sources:</dt>
                                   <dd></dd>

--- a/assets/app/views/builds.html
+++ b/assets/app/views/builds.html
@@ -45,7 +45,9 @@
                     <td class="hidden-xs">&nbsp;</td>
                     <td class="hidden-xs">&nbsp;</td>
                     <td data-title="Type">{{buildConfigs[buildConfigName].spec.strategy.type}}</td>
-                    <td data-title="Source"><span ng-if="buildConfigs[buildConfigName].spec.source.type == 'Git'" ng-bind-html='buildConfigs[buildConfigName].spec.source.git.uri | githubLink : buildConfigs[buildConfigName].spec.source.git.ref : buildConfigs[buildConfigName].spec.source.contextDir | linky'></span></td>
+                    <td data-title="Source">                        
+                      <span ng-if="buildConfigs[buildConfigName].spec.source.type == 'None'"><i>none</i></span>
+                      <span ng-if="buildConfigs[buildConfigName].spec.source.type == 'Git'" ng-bind-html='buildConfigs[buildConfigName].spec.source.git.uri | githubLink : buildConfigs[buildConfigName].spec.source.git.ref : buildConfigs[buildConfigName].spec.source.contextDir | linky'></span></td>
                   </tr>
                   <!-- Build config with builds, or builds whose build config has since been deleted -->
                   <!-- We only show the first build from a build config for now-->
@@ -95,6 +97,9 @@
                     <td data-title="Type">{{build.spec.strategy.type}}</td>
                     <td data-title="Source">
                       <span ng-if="build.spec.source">
+                        <span ng-if="build.spec.source.type == 'None'">
+                          <i>none</i>
+                        </span>
                         <span ng-if="build.spec.source.type == 'Git'" ng-bind-html='build.spec.source.git.uri | githubLink : build.spec.source.git.ref : build.spec.source.contextDir | linky' class="word-break"></span>
                       </span>
                     </td>

--- a/assets/app/views/edit/build-config.html
+++ b/assets/app/views/edit/build-config.html
@@ -189,6 +189,11 @@
                                 }" ng-model="updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline"></div>
                             </div>
                           </div>
+                          <div ng-if="sources.none">
+                            <div class="form-group">
+                              <i>No source inputs have been defined for this build configuration.</i>
+                            </div>
+                          </div>
 
                           <div class="form-groups" ng-show="sources.images">
 


### PR DESCRIPTION
This PR will sho the `None` source type to the user in the BC list and that the Source is `Not set` in the bc browse page and bc editor.

Here is the BCs browse page:
![screenshot-21](https://cloud.githubusercontent.com/assets/1668218/14667289/d5ca7c66-06de-11e6-90bd-38a4e8d0a723.png)

BC browse:
![screenshot-19](https://cloud.githubusercontent.com/assets/1668218/14667299/e2c4bad0-06de-11e6-82ce-318c181f44b8.png)
![screenshot-20](https://cloud.githubusercontent.com/assets/1668218/14667305/e4aff094-06de-11e6-8db9-a8e5bd1f503e.png)

BC editor:
![screenshot-17](https://cloud.githubusercontent.com/assets/1668218/14667336/0805c352-06df-11e6-97b7-589e7aa3d64f.png)
![screenshot-18](https://cloud.githubusercontent.com/assets/1668218/14667337/0940f2fa-06df-11e6-9f91-33e304aa6791.png)


No other special treatment was needed in any of the BC related controllers to tolerate `None` source type.

Also I would like to ask if it would make sense to split the `Configuration` section (in the configuration tab on the BC browse page)  to `Source Configuration` and `Image Configuration` like we have in the BC editor.